### PR TITLE
Fixed an issue where the queue wouldn't progress to the next song 

### DIFF
--- a/msgYoutube.go
+++ b/msgYoutube.go
@@ -134,7 +134,6 @@ func play(s *discordgo.Session, m *discordgo.MessageCreate, srvr *server, vc *di
 	}
 
 	srvr.VoiceInst.Lock()
-
 	vid, err := getVideoInfo(srvr.nextSong().URL, s, m)
 	if err != nil {
 		srvr.VoiceInst.Unlock()
@@ -193,6 +192,8 @@ Outer:
 			s.ChannelMessageSend(m.ChannelID, "There was an error streaming music :(")
 			log.Error("error streaming music", err)
 			return
+		case done && err == io.EOF:
+			break Outer
 		}
 	}
 


### PR DESCRIPTION
After putting in some logs, it seemed that the next call to `go play()` wasn't actually being run, but for some reason breaking from the Outer (just like what happens when `skip` is run) allows it to be called.

No idea why, maybe @Strum355 can tell me?

Also closes #18 